### PR TITLE
Set git user and email before committing

### DIFF
--- a/src/pytest_copier/plugin.py
+++ b/src/pytest_copier/plugin.py
@@ -76,6 +76,8 @@ def copier_template(
         copytree(copier_template_root, src, dirs_exist_ok=True)
 
     run("git", "init", cwd=src)
+    run("git", "config", "user.name", "User Name", cwd=src)
+    run("git", "config", "user.email", "user@email.org", cwd=src)
     run("git", "add", "-A", ".", cwd=src)
     run("git", "commit", "-m", "test", cwd=src)
     run("git", "tag", "99.99.99", cwd=src)


### PR DESCRIPTION
This makes git work also where a global configuration is not present, for example in the CI